### PR TITLE
[fix] #278 : Fixed link to LICENSE.md file in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Register for these sessions [here](https://forms.gle/aNyegaMbbuHtKoRV8)
 
 ## ⚖ License
 
-This project is licensed under the [MIT License](link-to-license).
+This project is licensed under the [MIT License](https://github.com/Chimoney/chimoney-community-projects/blob/main/LICENSE).
 
 ## 📧 Contact Information
 


### PR DESCRIPTION
I have resolved the error of redirection to LICENSE.md file from the README.md file by placing the actual valid link of the LICENSE.md  file.

Fixes #278 