### PR TITLE
docs: update submissions folder structure wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,9 @@ When you're ready to make a submission:
 - make your changes
 - and open a pull request.
 
-Be sure to include a clear description and follow the project folder structure; all contributions go into the `submissions/` directory, with your specific contribution placed in its relevant subfolder (e.g.
-
-- articles in the `articles/` folder
-- SDKs in the `SDKs/` folder
-
-).
+Be sure to include a clear description and follow the project folder structure; all contributions go into the submissions/ directory, with your specific contribution placed in its relevant subfolder, for example: 
+- Articles in the articles/ folder 
+- SDKs in the SDKs/ folder
 
 You can also read the full [Contribution Guidelines](/CONTRIBUTING.md) here to understand how to contribute effectively.
 


### PR DESCRIPTION
##  Title
docs: update submissions folder structure wording in README

---

##  Description
This PR updates the **Contributing** section of the `README.md` to make the folder structure instructions clearer and easier to follow for new contributors.

###  Changes Made
Replaced the existing text about the `submissions/` directory with the following clearer wording:

> Be sure to include a clear description and follow the project folder structure; all contributions go into the `submissions/` directory, with your specific contribution placed in its relevant subfolder, for example:
> - Articles in the `articles/` folder  
> - SDKs in the `SDKs/` folder

###  Purpose
This improves the readability and clarity of contribution instructions for first-time contributors, aligning with the project’s documentation standards.

---

##  Checklist
- [x] Updated `README.md`  
- [x] Used proper Markdown formatting  
- [x] Commit message follows conventional commits (`docs:` prefix)  
- [x] Linked the issue properly  

---

##  Issue Reference
Closes #515

---

## 🙋‍♂️ Request
Hi @phyleria 👋  
I’ve made the updates as per the instructions in the issue. Please review my PR whenever you get a chance. 😊
